### PR TITLE
Gs&Cs calculators: Fix HTML validation errors

### DIFF
--- a/CFP/calculator-contributions-en.html
+++ b/CFP/calculator-contributions-en.html
@@ -29,7 +29,7 @@
     </head>
 
 
-    <body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage"><nav><ul id="wb-tphp">
+    <body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage"><div class="par iparys_inherited"><div class="global-header"><nav><ul id="wb-tphp">
      <li class="wb-slc"><a class="wb-sl" href="#wb-cont">Skip to main content</a></li><li class="wb-slc visible-sm visible-md visible-lg"><a class="wb-sl" href="#wb-info">Skip to &#34;About government&#34;</a></li></ul></nav>
 
             <header>
@@ -171,8 +171,8 @@
              <h2>How to use this pattern</h2>
              <h3>Introducing the calculator</h3>
              <ul>
-                <li>The heading for this pattern must express the goal of the calculator</li>
-                <ul><li>for example, “Determine how much contributions you need to be eligible”</li></ul>
+                <li>The heading for this pattern must express the goal of the calculator
+                <ul><li>for example, “Determine how much contributions you need to be eligible”</li></ul></li>
                 <li>Optionally provide an overview of the results people can expect from using the calculator</li>
                 <li>Optionally provide brief instructions above the calculator</li>
              </ul>
@@ -197,14 +197,14 @@
                      </thead>
                      <tbody>
                      <tr id="row1" class="">
-                         <td id="cell1"class="small">What is the total cost of new, up-to-date equipment and/or materials, including tax (in CAD dollars)?</td>
-                         <td id="cell4"class="small">a number that user’s input</td>
+                         <td id="cell1" class="small">What is the total cost of new, up-to-date equipment and/or materials, including tax (in CAD dollars)?</td>
+                         <td id="cell4" class="small">a number that user’s input</td>
                          <td id="cell3"><var>a</var></td>
     
                      </tr>
                      <tr id="row2" class="">
-                         <td id="cell6"class="small">Choose your minimum cash contributions amount:</td>
-                         <td id="cell9"class="small">a fixed percentage set by program </td>
+                         <td id="cell6" class="small">Choose your minimum cash contributions amount:</td>
+                         <td id="cell9" class="small">a fixed percentage set by program </td>
                          <td id="cell8"><var>b</var></td>
     
                      </tr>
@@ -225,13 +225,13 @@
                      <tbody>
                      <tr id="row3">
                          <td id="cell11" class="small">ESDC funding amount</td>
-                         <td id="cell14"class="small">How much money ESDC will contribute to the project.</td>
+                         <td id="cell14" class="small">How much money ESDC will contribute to the project.</td>
                          <td id="cell13"><var>c</var></td>
                          <td id="cell15">=<var>a</var> x <var>b</var></td>
                      </tr>
                      <tr id="row4">
                          <td id="cell16" class="small">Project contribution (from other sources than ESDC)</td>
-                         <td id="cell19"class="small">How much money the applicant needs to contribute to the project.</td>
+                         <td id="cell19" class="small">How much money the applicant needs to contribute to the project.</td>
                          <td id="cell18"><var>d</var></td>
                          <td id="cell20">=<var>a</var> - <var>c</var></td>
                          </tr>
@@ -245,12 +245,12 @@
                       <form action="#" id="estimator" onsubmit="return false" novalidate="">
 
                             <div class="form-group">
-                              <p for="income"><strong>What is the total cost of new, up-to-date equipment and materials, including tax (in CAD dollars)?</strong></p>
+                              <label for="income"><strong>What is the total cost of new, up-to-date equipment and materials, including tax (in CAD dollars)?</strong></label>
                               <input class="form-control input-lg" type="number" name="income" id="income">
                             </div>
                             <div class="form-group">
                               <fieldset class="provisional gc-chckbxrdio">
-                                <p for ="contribution"><strong>Choose your minimum cash contributions amount:</strong></p>
+                                <p><strong>Choose your minimum cash contributions amount:</strong></p>
                               <ul class="list-unstyled lst-spcd-2">
                                 <li class="radio">
                                   <input type="radio" name="radioid" id="id1" value="50">
@@ -409,10 +409,9 @@
             <div class="pagedetails">
                 <dl id="wb-dtmd">
                     <dt>Date modified:</dt>
-                    <dd><time property="dateModified">2021-11-30</time></dd>
+                    <dd><time property="dateModified">2023-08-02</time></dd>
                 </dl>
             </div>
-        </div>
     </main>
 
     <div class="par iparys_inherited">


### PR DESCRIPTION
Specifically:
* Add MWS' opening ``div`` tags in page header
* Nest a sub-list properly
* Add spaces before ``class`` attributes
* Replace first ``input``'s paragraph with a label
* Remove ``fieldset`` paragraph's ``for`` attribute (turning it into a ``legend`` would've messed-up font sizes)
* Remove stray closing ``div`` tag after modified date

Notes:
* Only did the bare minimum to pass HTML validation
* Didn't resolve info/warning messages
* Labels look longer than paragraphs (``cnt-wdth-lmtd`` class doesn't reduce their widths)

CC @shanegord